### PR TITLE
Have `proto2ros` `mypy` checks follow imports silently

### DIFF
--- a/proto2ros/cmake/templates/mypy.ini.in
+++ b/proto2ros/cmake/templates/mypy.ini.in
@@ -1,5 +1,6 @@
 # Generated from cmake/templates/mypy.ini.in in the proto2ros package.
 [mypy]
+follow_imports = silent
 ignore_missing_imports = true
 mypy_path = "@MYPY_PATH@"
 # Ignore missing type annotations, mainly coming from ROS 2 imports.


### PR DESCRIPTION
## Proposed changes

https://build.ros2.org/job/Hdev__proto2ros__ubuntu_jammy_amd64/1 came out unstable because `mypy` is type-checking (and failing the type-check on) core packages such as `rclpy`. I cannot reproduce locally, so I suspect a difference in `mypy` versions. Either way, we should not be signaling errors in upstream packages. This patch avoids this.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes