### PR TITLE
Fix proto2ros C++ conversions template

### DIFF
--- a/proto2ros/proto2ros/output/templates/conversions.cpp.jinja
+++ b/proto2ros/proto2ros/output/templates/conversions.cpp.jinja
@@ -345,7 +345,7 @@ Convert({{ source }}, &{{ destination }});
 namespace {{ package_name }}::conversions {
 
 using proto2ros::conversions::Convert;
-{%- for namespace in config.cpp_conversion_namespaces %}
+{%- for namespace in config.inline_cpp_namespaces %}
 using {{ namespace }}::Convert;
 {%- endfor %}
 


### PR DESCRIPTION
## Proposed changes

Apparently I had a stroke while working on #1 and applied the inverse of this patch. It broke C++ conversions, and `proto2ros_tests` did not catch it because it has no dependency that isn't implicit (`proto2ros` is implicit, `proto2ros_tests` is implicit). I only found out when I tried to build https://github.com/bdaiinstitute/bosdyn_msgs :facepalm: 

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [ ] I have added tests that prove my changes are effective
- [ ] I have added necessary documentation to communicate the changes